### PR TITLE
Implement password update and advertisement features

### DIFF
--- a/ProjectData/sql/schema.sql
+++ b/ProjectData/sql/schema.sql
@@ -4,7 +4,9 @@ USE xiaomi_mall;
 CREATE TABLE users (
     id INT PRIMARY KEY AUTO_INCREMENT,
     username VARCHAR(50) NOT NULL UNIQUE,
-    password VARCHAR(50) NOT NULL
+    password VARCHAR(50) NOT NULL,
+    display_name VARCHAR(100),
+    avatar VARCHAR(255)
 );
 
 CREATE TABLE admins (
@@ -48,4 +50,12 @@ CREATE TABLE user_products (
     after_sale_status VARCHAR(20) DEFAULT '正常',
     FOREIGN KEY (user_id) REFERENCES users(id),
     FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+CREATE TABLE advertisements (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    image_url VARCHAR(255),
+    link VARCHAR(255),
+    enabled TINYINT DEFAULT 1
 );

--- a/src/ModelTest.java
+++ b/src/ModelTest.java
@@ -42,7 +42,13 @@ public class ModelTest {
 
         // 测试用户绑定商品及售后功能
         testUserProductOperations();
-        
+
+        // 测试广告功能
+        testAdvertisementOperations();
+
+        // 测试修改密码功能
+        testPasswordUpdate();
+
         System.out.println("\n所有测试完成！");
     }
     
@@ -374,6 +380,43 @@ public class ModelTest {
             }
         } catch (Exception e) {
             System.out.println("✗ 用户商品操作测试异常: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 测试广告相关操作
+     */
+    public static void testAdvertisementOperations() {
+        System.out.println("\n=== 测试广告操作 ===");
+
+        try {
+            int add = Model.addAdvertisement("测试广告", null, null, true);
+            System.out.println(add > 0 ? "✓ 添加广告成功" : "✗ 添加广告失败");
+
+            List<Advertisement> ads = Model.getAllAdvertisements();
+            System.out.println("✓ 当前广告数量: " + ads.size());
+
+            if (!ads.isEmpty()) {
+                Advertisement ad = ads.get(0);
+                Model.updateAdvertisement(ad.id, ad.title, ad.imageUrl, ad.link, ad.enabled);
+                Model.deleteAdvertisement(ad.id);
+            }
+        } catch (Exception e) {
+            System.out.println("✗ 广告操作测试异常: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 测试修改密码功能
+     */
+    public static void testPasswordUpdate() {
+        System.out.println("\n=== 测试密码修改 ===");
+        try {
+            Model.updateUserPassword(1, "newpass");
+            Model.updateAdminPassword(1, "newadminpass");
+            System.out.println("✓ 密码更新函数调用完成");
+        } catch (Exception e) {
+            System.out.println("✗ 密码修改测试异常: " + e.getMessage());
         }
     }
     

--- a/src/ServiceLayerTest.java
+++ b/src/ServiceLayerTest.java
@@ -26,7 +26,10 @@ public class ServiceLayerTest {
         
         // 测试售后服务
         testAfterSaleServices();
-        
+
+        // 测试广告服务
+        testAdvertisementServices();
+
         // 测试工具方法
         testUtilityMethods();
         
@@ -77,7 +80,13 @@ public class ServiceLayerTest {
         String longUsernameResult = ServiceLayer.userRegister(longUsername, password);
         System.out.println("长用户名注册结果: " + longUsernameResult);
         assert !"success".equals(longUsernameResult) || "success".equals(longUsernameResult) : "长用户名可能注册成功或失败";
-        
+
+        // 测试更新密码和资料
+        System.out.println("测试更新用户密码和资料...");
+        String pwdResult = ServiceLayer.updateUserPassword(1, "newpass123");
+        System.out.println("更新密码结果: " + pwdResult);
+        ServiceLayer.updateUserProfile(1, "测试用户", null);
+
         System.out.println("用户服务测试完成\n");
     }
     
@@ -99,7 +108,11 @@ public class ServiceLayerTest {
         boolean invalidAdminLoginResult = ServiceLayer.adminLogin("admin", "wrongpassword");
         System.out.println("无效管理员登录结果: " + invalidAdminLoginResult);
         assert !invalidAdminLoginResult : "无效管理员登录应该失败";
-        
+
+        System.out.println("测试更新管理员密码...");
+        String adminPwd = ServiceLayer.updateAdminPassword(1, "adminNew");
+        System.out.println("更新管理员密码结果: " + adminPwd);
+
         System.out.println("管理员服务测试完成\n");
     }
     
@@ -361,7 +374,33 @@ public class ServiceLayerTest {
         
         System.out.println("售后服务测试完成\n");
     }
-    
+
+    /**
+     * 测试广告相关服务
+     */
+    private static void testAdvertisementServices() {
+        System.out.println("========== 测试广告服务 ==========");
+
+        String title = "广告" + System.currentTimeMillis();
+        String addResult = ServiceLayer.addAdvertisement(title, null, null, true);
+        System.out.println("添加广告结果: " + addResult);
+        assert "success".equals(addResult) : "添加广告失败";
+
+        List<Advertisement> ads = ServiceLayer.getAllAdvertisements();
+        assert !ads.isEmpty() : "广告列表不应为空";
+
+        Advertisement ad = ads.get(ads.size() - 1);
+        String updateResult = ServiceLayer.updateAdvertisement(ad.id, ad.title + "_up", ad.imageUrl, ad.link, ad.enabled);
+        System.out.println("更新广告结果: " + updateResult);
+        assert "success".equals(updateResult) : "更新广告失败";
+
+        String deleteResult = ServiceLayer.deleteAdvertisement(ad.id);
+        System.out.println("删除广告结果: " + deleteResult);
+        assert "success".equals(deleteResult) : "删除广告失败";
+
+        System.out.println("广告服务测试完成\n");
+    }
+
     /**
      * 测试工具方法
      */

--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -29,9 +29,24 @@ public class Model {
         return UserDAO.addUser(username, password);
     }
 
+    /** 更新用户密码 */
+    public static int updateUserPassword(int userId, String newPassword) {
+        return UserDAO.updatePassword(userId, newPassword);
+    }
+
+    /** 更新用户资料 */
+    public static int updateUserProfile(int userId, String displayName, String avatar) {
+        return UserDAO.updateProfile(userId, displayName, avatar);
+    }
+
     /** 验证管理员登录 */
     public static boolean validateAdmin(String username, String password) {
         return AdminDAO.validateAdmin(username, password);
+    }
+
+    /** 更新管理员密码 */
+    public static int updateAdminPassword(int adminId, String newPassword) {
+        return AdminDAO.updatePassword(adminId, newPassword);
     }
 
     /** 获取所有商品 */
@@ -97,5 +112,25 @@ public class Model {
     /** 更新售后状态（管理员） */
     public static int updateAfterSaleStatus(int userProductId, String status) {
         return UserProductDAO.updateAfterSaleStatus(userProductId, status);
+    }
+
+    /** 获取所有广告 */
+    public static List<Advertisement> getAllAdvertisements() {
+        return AdvertisementDAO.getAllAdvertisements();
+    }
+
+    /** 新增广告 */
+    public static int addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
+        return AdvertisementDAO.addAdvertisement(title, imageUrl, link, enabled);
+    }
+
+    /** 更新广告 */
+    public static int updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
+        return AdvertisementDAO.updateAdvertisement(id, title, imageUrl, link, enabled);
+    }
+
+    /** 删除广告 */
+    public static int deleteAdvertisement(int id) {
+        return AdvertisementDAO.deleteAdvertisement(id);
     }
 }

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -110,6 +110,45 @@ public class ServiceLayer {
             return "系统错误，请稍后重试";
         }
     }
+
+    /**
+     * 更新用户密码
+     *
+     * @param userId 用户ID
+     * @param newPassword 新密码
+     * @return "success" 或错误信息
+     */
+    public static String updateUserPassword(int userId, String newPassword) {
+        if (userId <= 0) {
+            return "用户ID无效";
+        }
+        if (isEmpty(newPassword)) {
+            return "新密码不能为空";
+        }
+        try {
+            int result = Model.updateUserPassword(userId, newPassword);
+            return result > 0 ? "success" : "更新失败";
+        } catch (Exception e) {
+            System.err.println("更新用户密码失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
+        }
+    }
+
+    /**
+     * 更新用户资料
+     */
+    public static String updateUserProfile(int userId, String displayName, String avatar) {
+        if (userId <= 0) {
+            return "用户ID无效";
+        }
+        try {
+            int result = Model.updateUserProfile(userId, displayName, avatar);
+            return result > 0 ? "success" : "更新失败";
+        } catch (Exception e) {
+            System.err.println("更新用户资料失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
+        }
+    }
     
     // ==================== 管理员相关服务 ====================
     
@@ -132,7 +171,7 @@ public class ServiceLayer {
      * @return true-登录成功，false-登录失败
      */
     public static boolean adminLogin(String username, String password) {
-        if (username == null || username.trim().isEmpty() || 
+        if (username == null || username.trim().isEmpty() ||
             password == null || password.trim().isEmpty()) {
             return false;
         }
@@ -142,6 +181,25 @@ public class ServiceLayer {
         } catch (Exception e) {
             System.err.println("管理员登录验证失败: " + e.getMessage());
             return false;
+        }
+    }
+
+    /**
+     * 更新管理员密码
+     */
+    public static String updateAdminPassword(int adminId, String newPassword) {
+        if (adminId <= 0) {
+            return "管理员ID无效";
+        }
+        if (isEmpty(newPassword)) {
+            return "新密码不能为空";
+        }
+        try {
+            int result = Model.updateAdminPassword(adminId, newPassword);
+            return result > 0 ? "success" : "更新失败";
+        } catch (Exception e) {
+            System.err.println("更新管理员密码失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
         }
     }
     
@@ -650,6 +708,64 @@ public class ServiceLayer {
             }
         } catch (Exception e) {
             System.err.println("更新售后状态失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
+        }
+    }
+
+    // ==================== 广告相关服务 ====================
+
+    /** 获取所有广告 */
+    public static List<Advertisement> getAllAdvertisements() {
+        try {
+            List<Advertisement> ads = Model.getAllAdvertisements();
+            return ads != null ? ads : new ArrayList<>();
+        } catch (Exception e) {
+            System.err.println("获取广告列表失败: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    /** 新增广告 */
+    public static String addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
+        if (isEmpty(title)) {
+            return "标题不能为空";
+        }
+        try {
+            int r = Model.addAdvertisement(title, imageUrl, link, enabled);
+            return r > 0 ? "success" : "添加失败";
+        } catch (Exception e) {
+            System.err.println("添加广告失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
+        }
+    }
+
+    /** 更新广告 */
+    public static String updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
+        if (id <= 0) {
+            return "广告ID无效";
+        }
+        if (isEmpty(title)) {
+            return "标题不能为空";
+        }
+        try {
+            int r = Model.updateAdvertisement(id, title, imageUrl, link, enabled);
+            return r > 0 ? "success" : "更新失败";
+        } catch (Exception e) {
+            System.err.println("更新广告失败: " + e.getMessage());
+            return "系统错误，请稍后重试";
+        }
+    }
+
+    /** 删除广告 */
+    public static String deleteAdvertisement(int id) {
+        if (id <= 0) {
+            return "广告ID无效";
+        }
+        try {
+            int r = Model.deleteAdvertisement(id);
+            return r > 0 ? "success" : "删除失败";
+        } catch (Exception e) {
+            System.err.println("删除广告失败: " + e.getMessage());
             return "系统错误，请稍后重试";
         }
     }

--- a/src/com/dao/AdminDAO.java
+++ b/src/com/dao/AdminDAO.java
@@ -29,4 +29,24 @@ public class AdminDAO {
         }
         return false;
     }
+
+    /**
+     * 更新管理员密码。
+     *
+     * @param adminId 管理员ID
+     * @param newPassword 新密码
+     * @return 更新的行数
+     */
+    public static int updatePassword(int adminId, String newPassword) {
+        String sql = "UPDATE admins SET password=? WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, newPassword);
+            ps.setInt(2, adminId);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
 }

--- a/src/com/dao/AdvertisementDAO.java
+++ b/src/com/dao/AdvertisementDAO.java
@@ -1,0 +1,82 @@
+package com.dao;
+
+import com.db.DBUtil;
+import com.entity.Advertisement;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 广告相关数据库操作。
+ */
+public class AdvertisementDAO {
+
+    /** 获取所有广告 */
+    public static List<Advertisement> getAllAdvertisements() {
+        List<Advertisement> list = new ArrayList<>();
+        String sql = "SELECT * FROM advertisements";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                Advertisement ad = new Advertisement();
+                ad.id = rs.getInt("id");
+                ad.title = rs.getString("title");
+                ad.imageUrl = rs.getString("image_url");
+                ad.link = rs.getString("link");
+                ad.enabled = rs.getInt("enabled") == 1;
+                list.add(ad);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    /** 新增广告 */
+    public static int addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
+        String sql = "INSERT INTO advertisements(title, image_url, link, enabled) VALUES(?,?,?,?)";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, title);
+            ps.setString(2, imageUrl);
+            ps.setString(3, link);
+            ps.setInt(4, enabled ? 1 : 0);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    /** 更新广告 */
+    public static int updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
+        String sql = "UPDATE advertisements SET title=?, image_url=?, link=?, enabled=? WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, title);
+            ps.setString(2, imageUrl);
+            ps.setString(3, link);
+            ps.setInt(4, enabled ? 1 : 0);
+            ps.setInt(5, id);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    /** 删除广告 */
+    public static int deleteAdvertisement(int id) {
+        String sql = "DELETE FROM advertisements WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+}

--- a/src/com/dao/UserDAO.java
+++ b/src/com/dao/UserDAO.java
@@ -49,4 +49,46 @@ public class UserDAO {
         }
         return 0;
     }
+
+    /**
+     * 更新用户密码。
+     *
+     * @param userId 用户ID
+     * @param newPassword 新密码
+     * @return 更新的行数
+     */
+    public static int updatePassword(int userId, String newPassword) {
+        String sql = "UPDATE users SET password=? WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, newPassword);
+            ps.setInt(2, userId);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    /**
+     * 更新用户资料（头像和显示名称）。
+     *
+     * @param userId 用户ID
+     * @param displayName 显示名称
+     * @param avatar 头像URL
+     * @return 更新的行数
+     */
+    public static int updateProfile(int userId, String displayName, String avatar) {
+        String sql = "UPDATE users SET display_name=?, avatar=? WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, displayName);
+            ps.setString(2, avatar);
+            ps.setInt(3, userId);
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
 }

--- a/src/com/entity/Advertisement.java
+++ b/src/com/entity/Advertisement.java
@@ -1,0 +1,12 @@
+package com.entity;
+
+/**
+ * 广告实体。
+ */
+public class Advertisement {
+    public int id;
+    public String title;
+    public String imageUrl;
+    public String link;
+    public boolean enabled;
+}

--- a/web/test_all_functions.jsp
+++ b/web/test_all_functions.jsp
@@ -159,6 +159,7 @@
         <a href="#product-section">商品管理</a>
         <a href="#order-section">订单管理</a>
         <a href="#aftersale-section">售后管理</a>
+        <a href="#ad-section">广告管理</a>
         <a href="#utility-section">工具方法</a>
     </div>
 
@@ -233,6 +234,69 @@
         %>
         <div class="result <%=resultClass%>">
             登录结果: <%=result%>
+        </div>
+        <%
+            }
+        %>
+
+        <!-- 修改用户密码 -->
+        <h3>修改用户密码</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="updateUserPassword">
+            <div class="form-group">
+                <label>用户ID:</label>
+                <input type="number" name="updateUserId" value="1" required>
+            </div>
+            <div class="form-group">
+                <label>新密码:</label>
+                <input type="password" name="newUserPassword" required>
+            </div>
+            <button type="submit" class="btn">修改密码</button>
+        </form>
+
+        <%
+            if ("updateUserPassword".equals(action)) {
+                int uid = ServiceLayer.safeParseInt(request.getParameter("updateUserId"), 0);
+                String np = request.getParameter("newUserPassword");
+                result = ServiceLayer.updateUserPassword(uid, np);
+                resultClass = "success".equals(result) ? "success" : "error";
+        %>
+        <div class="result <%=resultClass%>">
+            修改密码结果: <%=result%>
+        </div>
+        <%
+            }
+        %>
+
+        <!-- 更新用户资料 -->
+        <h3>更新用户资料</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="updateUserProfile">
+            <div class="form-group">
+                <label>用户ID:</label>
+                <input type="number" name="profileUserId" value="1" required>
+            </div>
+            <div class="form-group">
+                <label>显示名称:</label>
+                <input type="text" name="displayName">
+            </div>
+            <div class="form-group">
+                <label>头像URL:</label>
+                <input type="text" name="avatar">
+            </div>
+            <button type="submit" class="btn">更新资料</button>
+        </form>
+
+        <%
+            if ("updateUserProfile".equals(action)) {
+                int uid = ServiceLayer.safeParseInt(request.getParameter("profileUserId"), 0);
+                String dn = request.getParameter("displayName");
+                String av = request.getParameter("avatar");
+                result = ServiceLayer.updateUserProfile(uid, dn, av);
+                resultClass = "success".equals(result) ? "success" : "error";
+        %>
+        <div class="result <%=resultClass%>">
+            更新资料结果: <%=result%>
         </div>
         <%
             }
@@ -795,9 +859,62 @@
         %>
     </div>
 
+    <!-- 广告管理测试 -->
+    <div id="ad-section" class="section">
+        <h2>6. 广告管理测试</h2>
+
+        <h3>添加广告</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="addAd">
+            <div class="form-group">
+                <label>标题:</label>
+                <input type="text" name="adTitle" required>
+            </div>
+            <button type="submit" class="btn">添加广告</button>
+        </form>
+
+        <%
+            if ("addAd".equals(action)) {
+                String title = request.getParameter("adTitle");
+                result = ServiceLayer.addAdvertisement(title, null, null, true);
+                resultClass = "success".equals(result) ? "success" : "error";
+        %>
+        <div class="result <%=resultClass%>">添加广告结果: <%=result%></div>
+        <%
+            }
+        %>
+
+        <h3>查看广告</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="listAd">
+            <button type="submit" class="btn">获取广告列表</button>
+        </form>
+
+        <%
+            if ("listAd".equals(action)) {
+                List<Advertisement> ads = ServiceLayer.getAllAdvertisements();
+        %>
+        <div class="result info">
+            <h4>广告列表(<%=ads.size()%>)</h4>
+            <% if (!ads.isEmpty()) { %>
+            <table>
+                <tr><th>ID</th><th>标题</th></tr>
+                <% for (Advertisement ad : ads) { %>
+                <tr><td><%=ad.id%></td><td><%=ad.title%></td></tr>
+                <% } %>
+            </table>
+            <% } else { %>
+            <p>暂无广告</p>
+            <% } %>
+        </div>
+        <%
+            }
+        %>
+    </div>
+
     <!-- 工具方法测试 -->
     <div id="utility-section" class="section">
-        <h2>6. 工具方法测试</h2>
+        <h2>7. 工具方法测试</h2>
 
         <h3>工具方法演示</h3>
         <div class="result info">


### PR DESCRIPTION
## Summary
- extend database schema with advertisement table and user avatar/display name
- support updating user/admin passwords and user profiles
- add advertisement DAO and entity with CRUD operations
- expose new functionality through `Model` and `ServiceLayer`
- expand tests and JSP demo page for password and ad features

## Testing
- `javac -cp lib/mysql-connector-j-8.0.33.jar -d out @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68527253aca4832f8dac197bba0f9bc6