### PR TITLE
Add image and link fields for advertisements

### DIFF
--- a/ProjectData/sql/schema.sql
+++ b/ProjectData/sql/schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE user_products (
 CREATE TABLE advertisements (
     id INT PRIMARY KEY AUTO_INCREMENT,
     title VARCHAR(100) NOT NULL,
-    image_url VARCHAR(255),
-    link VARCHAR(255),
+    image_path VARCHAR(255),
+    target_url VARCHAR(255),
     enabled TINYINT DEFAULT 1
 );

--- a/src/ModelTest.java
+++ b/src/ModelTest.java
@@ -390,7 +390,7 @@ public class ModelTest {
         System.out.println("\n=== 测试广告操作 ===");
 
         try {
-            int add = Model.addAdvertisement("测试广告", null, null, true);
+            int add = Model.addAdvertisement("测试广告", "img.png", "http://example.com", true);
             System.out.println(add > 0 ? "✓ 添加广告成功" : "✗ 添加广告失败");
 
             List<Advertisement> ads = Model.getAllAdvertisements();
@@ -398,7 +398,7 @@ public class ModelTest {
 
             if (!ads.isEmpty()) {
                 Advertisement ad = ads.get(0);
-                Model.updateAdvertisement(ad.id, ad.title, ad.imageUrl, ad.link, ad.enabled);
+                Model.updateAdvertisement(ad.id, ad.title, ad.imagePath, ad.targetUrl, ad.enabled);
                 Model.deleteAdvertisement(ad.id);
             }
         } catch (Exception e) {

--- a/src/ServiceLayerTest.java
+++ b/src/ServiceLayerTest.java
@@ -382,7 +382,9 @@ public class ServiceLayerTest {
         System.out.println("========== 测试广告服务 ==========");
 
         String title = "广告" + System.currentTimeMillis();
-        String addResult = ServiceLayer.addAdvertisement(title, null, null, true);
+        String img = "img" + System.currentTimeMillis() + ".png";
+        String url = "http://example.com";
+        String addResult = ServiceLayer.addAdvertisement(title, img, url, true);
         System.out.println("添加广告结果: " + addResult);
         assert "success".equals(addResult) : "添加广告失败";
 
@@ -390,7 +392,7 @@ public class ServiceLayerTest {
         assert !ads.isEmpty() : "广告列表不应为空";
 
         Advertisement ad = ads.get(ads.size() - 1);
-        String updateResult = ServiceLayer.updateAdvertisement(ad.id, ad.title + "_up", ad.imageUrl, ad.link, ad.enabled);
+        String updateResult = ServiceLayer.updateAdvertisement(ad.id, ad.title + "_up", ad.imagePath, ad.targetUrl, ad.enabled);
         System.out.println("更新广告结果: " + updateResult);
         assert "success".equals(updateResult) : "更新广告失败";
 

--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -120,13 +120,13 @@ public class Model {
     }
 
     /** 新增广告 */
-    public static int addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
-        return AdvertisementDAO.addAdvertisement(title, imageUrl, link, enabled);
+    public static int addAdvertisement(String title, String imagePath, String targetUrl, boolean enabled) {
+        return AdvertisementDAO.addAdvertisement(title, imagePath, targetUrl, enabled);
     }
 
     /** 更新广告 */
-    public static int updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
-        return AdvertisementDAO.updateAdvertisement(id, title, imageUrl, link, enabled);
+    public static int updateAdvertisement(int id, String title, String imagePath, String targetUrl, boolean enabled) {
+        return AdvertisementDAO.updateAdvertisement(id, title, imagePath, targetUrl, enabled);
     }
 
     /** 删除广告 */

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -726,12 +726,12 @@ public class ServiceLayer {
     }
 
     /** 新增广告 */
-    public static String addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
+    public static String addAdvertisement(String title, String imagePath, String targetUrl, boolean enabled) {
         if (isEmpty(title)) {
             return "标题不能为空";
         }
         try {
-            int r = Model.addAdvertisement(title, imageUrl, link, enabled);
+            int r = Model.addAdvertisement(title, imagePath, targetUrl, enabled);
             return r > 0 ? "success" : "添加失败";
         } catch (Exception e) {
             System.err.println("添加广告失败: " + e.getMessage());
@@ -740,7 +740,7 @@ public class ServiceLayer {
     }
 
     /** 更新广告 */
-    public static String updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
+    public static String updateAdvertisement(int id, String title, String imagePath, String targetUrl, boolean enabled) {
         if (id <= 0) {
             return "广告ID无效";
         }
@@ -748,7 +748,7 @@ public class ServiceLayer {
             return "标题不能为空";
         }
         try {
-            int r = Model.updateAdvertisement(id, title, imageUrl, link, enabled);
+            int r = Model.updateAdvertisement(id, title, imagePath, targetUrl, enabled);
             return r > 0 ? "success" : "更新失败";
         } catch (Exception e) {
             System.err.println("更新广告失败: " + e.getMessage());

--- a/src/com/dao/AdvertisementDAO.java
+++ b/src/com/dao/AdvertisementDAO.java
@@ -23,8 +23,8 @@ public class AdvertisementDAO {
                 Advertisement ad = new Advertisement();
                 ad.id = rs.getInt("id");
                 ad.title = rs.getString("title");
-                ad.imageUrl = rs.getString("image_url");
-                ad.link = rs.getString("link");
+                ad.imagePath = rs.getString("image_path");
+                ad.targetUrl = rs.getString("target_url");
                 ad.enabled = rs.getInt("enabled") == 1;
                 list.add(ad);
             }
@@ -35,13 +35,13 @@ public class AdvertisementDAO {
     }
 
     /** 新增广告 */
-    public static int addAdvertisement(String title, String imageUrl, String link, boolean enabled) {
-        String sql = "INSERT INTO advertisements(title, image_url, link, enabled) VALUES(?,?,?,?)";
+    public static int addAdvertisement(String title, String imagePath, String targetUrl, boolean enabled) {
+        String sql = "INSERT INTO advertisements(title, image_path, target_url, enabled) VALUES(?,?,?,?)";
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, title);
-            ps.setString(2, imageUrl);
-            ps.setString(3, link);
+            ps.setString(2, imagePath);
+            ps.setString(3, targetUrl);
             ps.setInt(4, enabled ? 1 : 0);
             return ps.executeUpdate();
         } catch (SQLException e) {
@@ -51,13 +51,13 @@ public class AdvertisementDAO {
     }
 
     /** 更新广告 */
-    public static int updateAdvertisement(int id, String title, String imageUrl, String link, boolean enabled) {
-        String sql = "UPDATE advertisements SET title=?, image_url=?, link=?, enabled=? WHERE id=?";
+    public static int updateAdvertisement(int id, String title, String imagePath, String targetUrl, boolean enabled) {
+        String sql = "UPDATE advertisements SET title=?, image_path=?, target_url=?, enabled=? WHERE id=?";
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, title);
-            ps.setString(2, imageUrl);
-            ps.setString(3, link);
+            ps.setString(2, imagePath);
+            ps.setString(3, targetUrl);
             ps.setInt(4, enabled ? 1 : 0);
             ps.setInt(5, id);
             return ps.executeUpdate();

--- a/src/com/entity/Advertisement.java
+++ b/src/com/entity/Advertisement.java
@@ -6,7 +6,7 @@ package com.entity;
 public class Advertisement {
     public int id;
     public String title;
-    public String imageUrl;
-    public String link;
+    public String imagePath;
+    public String targetUrl;
     public boolean enabled;
 }

--- a/web/test_all_functions.jsp
+++ b/web/test_all_functions.jsp
@@ -870,13 +870,23 @@
                 <label>标题:</label>
                 <input type="text" name="adTitle" required>
             </div>
+            <div class="form-group">
+                <label>图片路径:</label>
+                <input type="text" name="adImg">
+            </div>
+            <div class="form-group">
+                <label>跳转地址:</label>
+                <input type="text" name="adUrl">
+            </div>
             <button type="submit" class="btn">添加广告</button>
         </form>
 
         <%
             if ("addAd".equals(action)) {
                 String title = request.getParameter("adTitle");
-                result = ServiceLayer.addAdvertisement(title, null, null, true);
+                String img = request.getParameter("adImg");
+                String url = request.getParameter("adUrl");
+                result = ServiceLayer.addAdvertisement(title, img, url, true);
                 resultClass = "success".equals(result) ? "success" : "error";
         %>
         <div class="result <%=resultClass%>">添加广告结果: <%=result%></div>
@@ -898,9 +908,14 @@
             <h4>广告列表(<%=ads.size()%>)</h4>
             <% if (!ads.isEmpty()) { %>
             <table>
-                <tr><th>ID</th><th>标题</th></tr>
+                <tr><th>ID</th><th>标题</th><th>图片路径</th><th>跳转地址</th></tr>
                 <% for (Advertisement ad : ads) { %>
-                <tr><td><%=ad.id%></td><td><%=ad.title%></td></tr>
+                <tr>
+                    <td><%=ad.id%></td>
+                    <td><%=ad.title%></td>
+                    <td><%=ad.imagePath%></td>
+                    <td><%=ad.targetUrl%></td>
+                </tr>
                 <% } %>
             </table>
             <% } else { %>


### PR DESCRIPTION
## Summary
- update database schema to include `image_path` and `target_url` columns in `advertisements`
- expose new fields via `Advertisement` entity, DAO and service layer
- adjust tests to use the new advertisement fields
- extend JSP test page to input and display image and link information

## Testing
- `javac -cp lib/mysql-connector-j-8.0.33.jar -d bin @sources.txt`
- `java -cp bin:lib/mysql-connector-j-8.0.33.jar ModelTest | head`
- `java -cp bin:lib/mysql-connector-j-8.0.33.jar ServiceLayerTest | head`


------
https://chatgpt.com/codex/tasks/task_e_685279df8a98832fb430a0585da7e0f7