### PR TITLE
Improve SN binding validation

### DIFF
--- a/ProjectData/sql/schema.sql
+++ b/ProjectData/sql/schema.sql
@@ -58,7 +58,8 @@ CREATE TABLE user_products (
     order_no VARCHAR(8) NOT NULL,
     after_sale_status VARCHAR(20) DEFAULT '正常',
     FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (product_id) REFERENCES products(id)
+    FOREIGN KEY (product_id) REFERENCES products(id),
+    UNIQUE KEY uk_order_product(order_no, product_id)
 );
 
 CREATE TABLE advertisements (

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ JSP/
 
    * `bindUserProduct(int userId, int productId, String orderNo)`：绑定用户与商品关系。将 **订单号** 为 `orderNo` 且 **商品ID** 为 `productId` 的商品绑定到用户 `userId` 名下。内部会校验订单存在且属于该用户并已完成，符合条件则插入绑定记录。成功返回 `"success"`，否则返回错误原因（如“订单不存在或未完成”）。
    * `getUserProducts(int userId)`：获取用户已绑定的商品列表。返回列表中的每个 `UserProduct` 对象包含商品名称、订单号、售后状态等，可用于前端展示绑定商品及其售后进度。
+   * `getAllUserProducts()`：管理员查看所有用户绑定记录的列表，用于售后管理后台。
    * `applyAfterSale(int userProductId)`：用户申请售后服务。将对应绑定记录的 `after_sale_status` 更新为“申请中”，并返回 `"success"` 或失败信息。后续管理员处理结果再更新状态。
    * `updateAfterSaleStatus(int userProductId, String status)`：管理员更新售后状态。例如将状态改为“已处理”表示售后完成。返回 `"success"` 或错误信息（如记录不存在等）。
    * `getUserProductById(int id)`：根据绑定记录ID获取具体的绑定信息（包括哪个用户、商品及订单号，以及当前售后状态）。

--- a/SERVICE_LAYER_API.md
+++ b/SERVICE_LAYER_API.md
@@ -131,6 +131,10 @@
 获取用户绑定的所有产品信息。
 - **userId**: 用户 ID
 
+### `List<UserProduct> getAllUserProducts()`
+管理员获取所有用户商品绑定记录。
+返回值为 `UserProduct` 列表，用于后台查看售后申请。
+
 ### `String applyAfterSale(int userProductId)`
 提交品质或维修等售后申请，成功返回 "success"。
 - **userProductId**: 用户产品绑定 ID

--- a/src/ServiceLayerTest.java
+++ b/src/ServiceLayerTest.java
@@ -405,6 +405,14 @@ public class ServiceLayerTest {
             }
         }
         assert boundProduct != null : "未找到刚绑定的商品";
+
+        // 再次尝试绑定同一商品，应该失败
+        String duplicateBind = ServiceLayer.bindUserProduct(userId, testProduct.id, o.orderNo);
+        assert !"success".equals(duplicateBind) : "重复绑定应该失败";
+
+        // 尝试绑定订单中不存在的商品
+        String invalidBind = ServiceLayer.bindUserProduct(userId, 999999, o.orderNo);
+        assert !"success".equals(invalidBind) : "订单中不存在的商品绑定应失败";
         
         // 申请售后
         System.out.println("测试申请售后...");
@@ -439,6 +447,12 @@ public class ServiceLayerTest {
             }
         }
         assert statusUpdated : "售后状态未成功更新为'已处理'";
+
+        // 获取所有绑定记录
+        System.out.println("测试获取所有绑定记录...");
+        List<UserProduct> allBindings = ServiceLayer.getAllUserProducts();
+        System.out.println("所有绑定记录数量: " + allBindings.size());
+        assert !allBindings.isEmpty() : "所有绑定记录列表不应为空";
 
         // 根据ID获取绑定商品并删除
         UserProduct fetchedUP = ServiceLayer.getUserProductById(boundProduct.id);

--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -134,9 +134,25 @@ public class Model {
         return UserProductDAO.addUserProduct(userId, productId, orderNo);
     }
 
+    /**
+     * 检查指定订单号与商品ID是否已有绑定记录。
+     *
+     * @param orderNo   订单号
+     * @param productId 商品ID
+     * @return true 已存在绑定，false 不存在
+     */
+    public static boolean userProductExists(String orderNo, int productId) {
+        return UserProductDAO.existsByOrderAndProduct(orderNo, productId);
+    }
+
     /** 查询用户绑定的商品 */
     public static List<UserProduct> getUserProducts(int userId) {
         return UserProductDAO.getUserProducts(userId);
+    }
+
+    /** 获取所有用户绑定商品（管理员） */
+    public static List<UserProduct> getAllUserProducts() {
+        return UserProductDAO.getAllUserProducts();
     }
 
     /** 用户申请售后 */

--- a/src/com/dao/UserProductDAO.java
+++ b/src/com/dao/UserProductDAO.java
@@ -35,6 +35,28 @@ public class UserProductDAO {
     }
 
     /**
+     * 检查指定订单号与商品ID组合是否已存在绑定记录。
+     *
+     * @param orderNo   订单号
+     * @param productId 商品ID
+     * @return true 表示已存在，false 表示不存在或查询失败
+     */
+    public static boolean existsByOrderAndProduct(String orderNo, int productId) {
+        String sql = "SELECT 1 FROM user_products WHERE order_no=? AND product_id=? LIMIT 1";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, orderNo);
+            ps.setInt(2, productId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    /**
      * 查询用户绑定的所有商品。
      *
      * @param userId 用户ID
@@ -58,6 +80,34 @@ public class UserProductDAO {
                     up.productName = rs.getString("name");
                     list.add(up);
                 }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    /**
+     * 获取所有用户商品绑定记录（管理员使用）。
+     *
+     * @return 绑定记录列表
+     */
+    public static List<UserProduct> getAllUserProducts() {
+        List<UserProduct> list = new ArrayList<>();
+        String sql = "SELECT up.id, up.user_id, up.product_id, up.order_no, up.after_sale_status, p.name " +
+                     "FROM user_products up JOIN products p ON up.product_id=p.id ORDER BY up.id DESC";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                UserProduct up = new UserProduct();
+                up.id = rs.getInt("id");
+                up.userId = rs.getInt("user_id");
+                up.productId = rs.getInt("product_id");
+                up.orderNo = rs.getString("order_no");
+                up.afterSaleStatus = rs.getString("after_sale_status");
+                up.productName = rs.getString("name");
+                list.add(up);
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/web/test_all_functions.jsp
+++ b/web/test_all_functions.jsp
@@ -993,6 +993,7 @@
             </div>
             <button type="submit" class="btn">绑定商品</button>
         </form>
+        <p class="info">系统会校验商品是否属于该订单，且同一订单号与商品只能绑定一次。</p>
 
         <%
             if ("bindUserProduct".equals(action)) {
@@ -1050,6 +1051,40 @@
             </table>
             <% } else { %>
             <p>该用户暂无绑定商品</p>
+            <% } %>
+        </div>
+        <%
+            }
+        %>
+
+        <!-- 获取所有绑定记录（管理员功能） -->
+        <h3>获取所有绑定记录</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="getAllUserProducts">
+            <button type="submit" class="btn">获取全部绑定记录</button>
+        </form>
+
+        <%
+            if ("getAllUserProducts".equals(action)) {
+                List<UserProduct> allList = ServiceLayer.getAllUserProducts();
+        %>
+        <div class="result info">
+            <h4>全部绑定记录 (共<%=allList.size()%>条):</h4>
+            <% if (!allList.isEmpty()) { %>
+            <table>
+                <tr><th>ID</th><th>用户ID</th><th>商品</th><th>订单号</th><th>售后状态</th></tr>
+                <% for (UserProduct up : allList) { %>
+                <tr>
+                    <td><%=up.id%></td>
+                    <td><%=up.userId%></td>
+                    <td><%=up.productName%></td>
+                    <td><%=up.orderNo%></td>
+                    <td><%=up.afterSaleStatus%></td>
+                </tr>
+                <% } %>
+            </table>
+            <% } else { %>
+            <p>暂无绑定记录</p>
             <% } %>
         </div>
         <%


### PR DESCRIPTION
## Summary
- add unique constraint to `user_products`
- provide DAO helper `existsByOrderAndProduct`
- expose `userProductExists` in `Model`
- tighten validation logic in `ServiceLayer.bindUserProduct`
- extend after-sale tests and update JSP hint
- add method to list all user product bindings

## Testing
- `javac -cp lib/mysql-connector-j-8.0.33.jar -d out @sources.txt`
- `java -cp out:lib/mysql-connector-j-8.0.33.jar ServiceLayerTest` *(fails: The url cannot be null)*

------
https://chatgpt.com/codex/tasks/task_e_6853b015f0e8832fa872fe1175bd3b30