### PR TITLE
Implement SN code allocation to orders

### DIFF
--- a/ProjectData/sql/schema.sql
+++ b/ProjectData/sql/schema.sql
@@ -110,3 +110,11 @@ CREATE TABLE IF NOT EXISTS notifications (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS order_sn_codes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT NOT NULL,
+    sn_code VARCHAR(100) NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(id),
+    UNIQUE KEY (sn_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -212,6 +212,18 @@ public class Model {
         return snCodeDAO.deleteByBatch(batchId);
     }
 
+    public static List<SNCode> getAvailableSNCodes(int productId, int limit) throws SQLException {
+        return snCodeDAO.listAvailable(productId, limit);
+    }
+
+    public static void assignSNCodes(int orderId, List<SNCode> codes) throws SQLException {
+        snCodeDAO.assignToOrder(orderId, codes);
+    }
+
+    public static List<SNCode> getSNCodesByOrder(int orderId) throws SQLException {
+        return snCodeDAO.listByOrder(orderId);
+    }
+
     // Bindings
     public static int bindSN(int userId, String code) throws SQLException {
         return bindingDAO.bind(userId, code);

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -374,7 +374,16 @@ public class ServiceLayer {
 
     public static boolean markOrderPaid(int id) {
         try {
-            return Model.markOrderPaid(id) > 0;
+            Order order = Model.getOrderById(id);
+            if(order == null) return false;
+            if(Model.markOrderPaid(id) <= 0) return false;
+            if(order.getItems() != null){
+                for(OrderItem item : order.getItems()){
+                    List<SNCode> codes = Model.getAvailableSNCodes(item.getProductId(), item.getQuantity());
+                    Model.assignSNCodes(id, codes);
+                }
+            }
+            return true;
         } catch (SQLException e) {
             e.printStackTrace();
             return false;
@@ -433,6 +442,15 @@ public class ServiceLayer {
         } catch (SQLException e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    public static List<SNCode> getSNCodesByOrder(int orderId) {
+        try {
+            return Model.getSNCodesByOrder(orderId);
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return Collections.emptyList();
         }
     }
 

--- a/web/admin/pages/order/order-detail.jsp
+++ b/web/admin/pages/order/order-detail.jsp
@@ -173,6 +173,19 @@
     %>
 </div>
 
+<!-- SN码列表 -->
+<div class="order-detail-section">
+    <h4>SN码列表</h4>
+    <ul>
+        <%
+            java.util.List<com.entity.SNCode> snList = com.ServiceLayer.getSNCodesByOrder(order.getId());
+            for(com.entity.SNCode sn : snList){
+        %>
+        <li><%= sn.getCode() %></li>
+        <% } %>
+    </ul>
+</div>
+
 <%
     } catch (NumberFormatException e) {
         out.println("<div style='text-align: center; padding: 50px; color: red;'>订单ID格式错误</div>");

--- a/web/index/payment.jsp
+++ b/web/index/payment.jsp
@@ -63,6 +63,17 @@
         <h3>✓ 订单已支付</h3>
         <p>订单号：<%= order.getId() %></p>
         <p>支付金额：¥<%= order.getTotal() %></p>
+        <div class="sn-list">
+            <h4>SN码列表</h4>
+            <ul>
+                <%
+                    java.util.List<com.entity.SNCode> snList = com.ServiceLayer.getSNCodesByOrder(order.getId());
+                    for(com.entity.SNCode sn : snList){
+                %>
+                <li><%= sn.getCode() %></li>
+                <% } %>
+            </ul>
+        </div>
         <a href="orders.jsp" class="back-link">← 返回订单列表</a>
     </div>
     <% }else{ %>


### PR DESCRIPTION
## Summary
- extend SQL schema with `order_sn_codes` table
- add SNCodeDAO support for assigning and fetching order SN codes
- expose new methods in Model and ServiceLayer
- allocate SN codes when marking an order as paid
- display SN codes on payment and admin order detail pages

## Testing
- `find src -name "*.java" | xargs javac -d out -cp lib/mysql-connector-j-8.0.33.jar`

------
https://chatgpt.com/codex/tasks/task_e_6858188de914832fb2043b5c3acdd7b3