### PR TITLE
Fix order detail navigation

### DIFF
--- a/web/index/css/order-detail.css
+++ b/web/index/css/order-detail.css
@@ -1,0 +1,57 @@
+.detail-header {
+    background: #fff;
+    padding: 12px 16px;
+    border-bottom: 1px solid #e0e0e0;
+    display: flex;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+.back-btn {
+    background: none;
+    border: none;
+    font-size: 18px;
+    color: #333;
+    cursor: pointer;
+    margin-right: 12px;
+    padding: 4px;
+}
+.header-title {
+    font-size: 16px;
+    font-weight: 500;
+    color: #333;
+    flex: 1;
+    text-align: center;
+    margin-right: 30px;
+}
+.detail-container {
+    padding: 16px;
+}
+.order-info, .address-info {
+    background: #fff;
+    padding: 12px;
+    border-radius: 8px;
+    margin-bottom: 10px;
+    font-size: 14px;
+    color: #333;
+}
+.items-section {
+    background: #fff;
+    padding: 12px;
+    border-radius: 8px;
+}
+.item-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 14px;
+    color: #333;
+}
+.item-row:last-child {
+    border-bottom: none;
+}
+.item-name { flex: 1; }
+.item-qty { width: 40px; text-align: center; }
+.item-price { width: 60px; text-align: right; }

--- a/web/index/css/orders.css
+++ b/web/index/css/orders.css
@@ -105,3 +105,19 @@
             background: #ccc;
             cursor: not-allowed;
         }
+        .btn-detail {
+            background: #fff;
+            border: 1px solid #ff6b35;
+            color: #ff6b35;
+            border-radius: 20px;
+            padding: 8px 16px;
+            font-size: 12px;
+            text-decoration: none;
+            display: inline-block;
+            transition: all 0.3s;
+        }
+        .btn-detail:hover {
+            background: #ff6b35;
+            color: #fff;
+            text-decoration: none;
+        }

--- a/web/index/order-detail.jsp
+++ b/web/index/order-detail.jsp
@@ -1,0 +1,62 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="com.ServiceLayer" %>
+<%@ page import="com.entity.*" %>
+<%
+    Object obj = session.getAttribute("user");
+    if(obj == null){ response.sendRedirect("login.jsp"); return; }
+    User u = (User)obj;
+    request.setCharacterEncoding("UTF-8");
+
+    String idStr = request.getParameter("id");
+    if(idStr == null){ response.sendRedirect("orders.jsp"); return; }
+    int orderId = Integer.parseInt(idStr);
+    Order order = ServiceLayer.getOrderById(orderId);
+    if(order == null || order.getUserId() != u.getId()){ response.sendRedirect("orders.jsp"); return; }
+
+    java.util.List<OrderItem> items = order.getItems();
+    Address address = null;
+    java.util.List<Address> adds = ServiceLayer.getAddresses(u.getId());
+    if(adds != null){
+        for(Address a : adds){ if(a.getId() == order.getAddressId()){ address = a; break; } }
+    }
+%>
+<html>
+<head>
+    <title>订单详情</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <link rel="stylesheet" href="css/main.css"/>
+    <link rel="stylesheet" href="css/order-detail.css"/>
+</head>
+<body>
+<div class="detail-header">
+    <button class="back-btn" onclick="history.back();">←</button>
+    <div class="header-title">订单详情</div>
+</div>
+
+<div class="detail-container">
+    <div class="order-info">
+        <div>订单号：<%= order.getId() %></div>
+        <div>状态：<%= order.getStatus() %></div>
+        <div>总金额：¥<%= order.getTotal() %></div>
+    </div>
+    <% if(address != null){ %>
+    <div class="address-info">
+        <div><%= address.getReceiver() %> <%= address.getPhone() %></div>
+        <div><%= address.getDetail() %></div>
+    </div>
+    <% } %>
+    <div class="items-section">
+        <% for(OrderItem item : items){ Product p = ServiceLayer.getProductById(item.getProductId()); %>
+        <div class="item-row">
+            <div class="item-name"><%= p!=null ? p.getName() : ("商品"+item.getProductId()) %></div>
+            <div class="item-qty">x<%= item.getQuantity() %></div>
+            <div class="item-price">¥<%= item.getPrice() %></div>
+        </div>
+        <% } %>
+    </div>
+</div>
+
+<!-- 底部导航 -->
+<jsp:include page="footer.jsp" />
+</body>
+</html>

--- a/web/index/orders.jsp
+++ b/web/index/orders.jsp
@@ -100,6 +100,7 @@
             <div class="order-total">¥<%= o.getTotal() %></div>
             <div style="font-size: 12px; color: #999; margin: 5px 0;">状态：<%= o.getStatus() %></div>
             <div class="order-actions">
+                <a href="order-detail.jsp?id=<%= o.getId() %>" class="btn-detail">查看详情</a>
                 <% if(!o.isPaid()){ %>
                 <a href="payment.jsp?orderId=<%= o.getId() %>" class="btn-pay">立即支付</a>
                 <% } %>


### PR DESCRIPTION
## Summary
- allow users to see order details
- add `order-detail.jsp` page to display items in an order
- style new page with `order-detail.css`
- show "查看详情" link for each order in `orders.jsp`

## Testing
- `javac -d out -cp lib/mysql-connector-j-8.0.33.jar $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_68581db0c66c832fafd6c9e6c74a9c2d