### PR TITLE
Fix order SN code generation and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 3. **购物车 & 订单模块**  
    - 购物车操作：添加、修改数量、删除、查看列表  
    - 下单流程：选择地址、生成订单、锁定库存  
-   - 支付回调：标记已支付，触发 SN 分配  
+   - 支付回调：标记已支付，触发 SN 分配（为每件商品生成 SN 并记录到 `sn_codes`，批次号为订单ID）
    - 订单查询：用户查看自有订单，管理员分页／筛选查看全部  
    - 订单状态管理：用户取消、管理员发货／关闭等
 
@@ -93,7 +93,7 @@
 - **管理员**：`generateSNCodes(productId, batchSize)`  
 - **管理员**：`listSNCodes(productId, status, page, pageSize)`  
 - **管理员**：`updateSNStatus(snCode, newStatus)`  
-- **管理员**：`deleteSNCodes(batchId)`  
+- **管理员**：`deleteSNCodes(batchId)`
 - `getSNCodesByOrder(orderId)`
 
 ### 5. SN 绑定模块  

--- a/SERVICE_LAYER_API.md
+++ b/SERVICE_LAYER_API.md
@@ -53,6 +53,7 @@
 ## SN 码相关
 - **`void generateSNCodes(int productId, int size, int batchId)`**：批量生成 SN 码。
 - **`List<SNCode> listSNCodes(int productId, String status)`**：按商品和状态查询 SN 列表。
+- **`List<SNCode> getSNCodesByOrder(int orderId)`**：获取指定订单生成的 SN 列表。
 - **`boolean updateSNStatus(String code, String status)`**：更新单个 SN 的状态。
 - **`boolean deleteSNCodes(int batchId)`**：按批次删除 SN 码。
 

--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -200,8 +200,16 @@ public class Model {
         snCodeDAO.generate(productId, size, batchId);
     }
 
+    public static void generateSNCodes(int productId, int size, int batchId, String status) throws SQLException {
+        snCodeDAO.generate(productId, size, batchId, status);
+    }
+
     public static List<SNCode> listSNCodes(int productId, String status) throws SQLException {
         return snCodeDAO.list(productId, status);
+    }
+
+    public static List<SNCode> listSNCodesByBatch(int batchId) throws SQLException {
+        return snCodeDAO.listByBatch(batchId);
     }
 
     public static int updateSNStatus(String code, String status) throws SQLException {

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -374,7 +374,16 @@ public class ServiceLayer {
 
     public static boolean markOrderPaid(int id) {
         try {
-            return Model.markOrderPaid(id) > 0;
+            boolean ok = Model.markOrderPaid(id) > 0;
+            if (ok) {
+                Order o = Model.getOrderById(id);
+                if (o != null && o.getItems() != null) {
+                    for (OrderItem item : o.getItems()) {
+                        Model.generateSNCodes(item.getProductId(), item.getQuantity(), id, "sold");
+                    }
+                }
+            }
+            return ok;
         } catch (SQLException e) {
             e.printStackTrace();
             return false;
@@ -412,6 +421,15 @@ public class ServiceLayer {
     public static List<SNCode> listSNCodes(int productId, String status) {
         try {
             return Model.listSNCodes(productId, status);
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+
+    public static List<SNCode> getSNCodesByOrder(int orderId) {
+        try {
+            return Model.listSNCodesByBatch(orderId);
         } catch (SQLException e) {
             e.printStackTrace();
             return Collections.emptyList();

--- a/web/index/css/order-detail.css
+++ b/web/index/css/order-detail.css
@@ -55,3 +55,10 @@
 .item-name { flex: 1; }
 .item-qty { width: 40px; text-align: center; }
 .item-price { width: 60px; text-align: right; }
+
+.sn-row {
+    padding: 4px 0;
+    font-size: 12px;
+    color: #666;
+    border-bottom: 1px dashed #eee;
+}

--- a/web/index/order-detail.jsp
+++ b/web/index/order-detail.jsp
@@ -14,6 +14,7 @@
     if(order == null || order.getUserId() != u.getId()){ response.sendRedirect("orders.jsp"); return; }
 
     java.util.List<OrderItem> items = order.getItems();
+    java.util.List<SNCode> snList = ServiceLayer.getSNCodesByOrder(orderId);
     Address address = null;
     java.util.List<Address> adds = ServiceLayer.getAddresses(u.getId());
     if(adds != null){
@@ -52,6 +53,9 @@
             <div class="item-qty">x<%= item.getQuantity() %></div>
             <div class="item-price">¥<%= item.getPrice() %></div>
         </div>
+        <% for(SNCode sn : snList){ if(sn.getProductId()==item.getProductId()){ %>
+        <div class="sn-row">SN: <%= sn.getCode() %></div>
+        <% }} %>
         <% } %>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- generate SN codes when marking an order paid
- add helper API for listing SN codes by order
- show SN codes in the order detail page
- update docs for the new API and behaviour
- improve order-detail styles for SN list

## Testing
- `javac -d out -cp lib/mysql-connector-j-8.0.33.jar $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_685820252088832f8996d58129b874fa