### PR TITLE
Prevent deleting addresses referenced by orders

### DIFF
--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -128,6 +128,11 @@ public class Model {
         return addressDAO.listAll();
     }
 
+    // Check if an address is referenced by any order
+    public static boolean addressHasOrders(int addressId) throws SQLException {
+        return orderDAO.existsByAddressId(addressId);
+    }
+
     // Category operations
     public static List<Category> listCategories() throws SQLException {
         return categoryDAO.listAll();

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -227,7 +227,24 @@ public class ServiceLayer {
 
     public static boolean deleteAddress(int id) {
         try {
+            // If the address is used by any order, do not attempt deletion
+            if (Model.addressHasOrders(id)) {
+                return false;
+            }
             return Model.deleteAddress(id) > 0;
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Determine whether an address can be safely deleted.
+     * Returns true if any order references this address.
+     */
+    public static boolean addressHasOrders(int addressId) {
+        try {
+            return Model.addressHasOrders(addressId);
         } catch (SQLException e) {
             e.printStackTrace();
             return false;

--- a/src/com/dao/OrderDAO.java
+++ b/src/com/dao/OrderDAO.java
@@ -99,6 +99,21 @@ public class OrderDAO {
         }
     }
 
+    /**
+     * Check whether there are any orders using the specified address.
+     * This is used before deleting an address to prevent foreign key violations.
+     */
+    public boolean existsByAddressId(int addressId) throws SQLException {
+        String sql = "SELECT 1 FROM orders WHERE address_id=? LIMIT 1";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, addressId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
     private Order map(ResultSet rs) throws SQLException {
         Order o = new Order();
         o.setId(rs.getInt("id"));

--- a/web/index/addresses.jsp
+++ b/web/index/addresses.jsp
@@ -31,7 +31,13 @@
         if(ServiceLayer.updateAddress(a)) message="已更新"; else message="更新失败";
     }else if("delete".equals(action)){
         int id = Integer.parseInt(request.getParameter("id"));
-        if(ServiceLayer.deleteAddress(id)) message="已删除"; else message="删除失败";
+        if(ServiceLayer.addressHasOrders(id)){
+            message = "删除失败：该地址已在订单中使用";
+        }else if(ServiceLayer.deleteAddress(id)){
+            message = "已删除";
+        }else{
+            message = "删除失败";
+        }
     }else if("default".equals(action)){
         int id = Integer.parseInt(request.getParameter("id"));
         ServiceLayer.setDefaultAddress(u.getId(), id);


### PR DESCRIPTION
## Summary
- add DAO method to check whether any orders use an address
- expose address-use check via Model and ServiceLayer
- block deletion if orders exist and show message on the address page

## Testing
- `javac -d out -cp lib/mysql-connector-j-8.0.33.jar $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_6858c21125a8832f98440b12739195fc