### PR TITLE
Fix user deletion by cascading related data

### DIFF
--- a/src/com/Model.java
+++ b/src/com/Model.java
@@ -275,6 +275,27 @@ public class Model {
         return bindingDAO.deleteByUserId(userId);
     }
 
+    // Additional helpers for deleting data related to a user
+    public static int deleteCartItemsByUser(int userId) throws SQLException {
+        return cartDAO.deleteByUserId(userId);
+    }
+
+    public static int deleteAfterSalesByUser(int userId) throws SQLException {
+        return afterSaleDAO.deleteByUserId(userId);
+    }
+
+    public static int deleteNotificationsByUser(int userId) throws SQLException {
+        return notificationDAO.deleteByUserId(userId);
+    }
+
+    public static int deleteOrdersByUser(int userId) throws SQLException {
+        return orderDAO.deleteByUser(userId);
+    }
+
+    public static int deleteAddressesByUser(int userId) throws SQLException {
+        return addressDAO.deleteByUserId(userId);
+    }
+
     // After sale
     public static int applyAfterSale(AfterSale a) throws SQLException {
         return afterSaleDAO.insert(a);

--- a/src/com/ServiceLayer.java
+++ b/src/com/ServiceLayer.java
@@ -75,8 +75,13 @@ public class ServiceLayer {
 
     public static boolean deleteUser(int id) {
         try {
-            // Remove related bindings first to avoid foreign key violations
+            // Remove related records to avoid foreign key violations
             Model.deleteBindingsByUser(id);
+            Model.deleteCartItemsByUser(id);
+            Model.deleteAfterSalesByUser(id);
+            Model.deleteNotificationsByUser(id);
+            Model.deleteOrdersByUser(id);
+            Model.deleteAddressesByUser(id);
             return Model.deleteUser(id) > 0;
         } catch (SQLException e) {
             e.printStackTrace();
@@ -90,17 +95,16 @@ public class ServiceLayer {
     }
 
     public static boolean batchDeleteUsers(int[] ids) {
-        try {
-            if (ids != null) {
-                for (int id : ids) {
-                    Model.deleteBindingsByUser(id);
-                }
-            }
-            return Model.batchDeleteUsers(ids) > 0;
-        } catch (SQLException e) {
-            e.printStackTrace();
+        if (ids == null || ids.length == 0) {
             return false;
         }
+        boolean all = true;
+        for (int id : ids) {
+            if (!deleteUser(id)) {
+                all = false;
+            }
+        }
+        return all;
     }
 
     // 商品相关

--- a/src/com/dao/AddressDAO.java
+++ b/src/com/dao/AddressDAO.java
@@ -64,6 +64,18 @@ public class AddressDAO {
         }
     }
 
+    /**
+     * Delete all addresses for a specific user.
+     */
+    public int deleteByUserId(int userId) throws SQLException {
+        String sql = "DELETE FROM addresses WHERE user_id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            return ps.executeUpdate();
+        }
+    }
+
     public void setDefault(int userId, int addressId) throws SQLException {
         String unset = "UPDATE addresses SET is_default=0 WHERE user_id=?";
         String set = "UPDATE addresses SET is_default=1 WHERE id=?";

--- a/src/com/dao/AfterSaleDAO.java
+++ b/src/com/dao/AfterSaleDAO.java
@@ -70,6 +70,18 @@ public class AfterSaleDAO {
         }
     }
 
+    /**
+     * Delete all after-sale records for the specified user.
+     */
+    public int deleteByUserId(int userId) throws SQLException {
+        String sql = "DELETE FROM after_sales WHERE user_id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            return ps.executeUpdate();
+        }
+    }
+
     private AfterSale map(ResultSet rs) throws SQLException {
         AfterSale a = new AfterSale();
         a.setId(rs.getInt("id"));

--- a/src/com/dao/CartDAO.java
+++ b/src/com/dao/CartDAO.java
@@ -55,6 +55,18 @@ public class CartDAO {
         }
     }
 
+    /**
+     * Delete all cart items for the specified user.
+     */
+    public int deleteByUserId(int userId) throws SQLException {
+        String sql = "DELETE FROM cart_items WHERE user_id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            return ps.executeUpdate();
+        }
+    }
+
     private CartItem map(ResultSet rs) throws SQLException {
         CartItem c = new CartItem();
         c.setId(rs.getInt("id"));

--- a/src/com/dao/NotificationDAO.java
+++ b/src/com/dao/NotificationDAO.java
@@ -54,6 +54,18 @@ public class NotificationDAO {
         }
     }
 
+    /**
+     * Delete all notifications for a specific user.
+     */
+    public int deleteByUserId(int userId) throws SQLException {
+        String sql = "DELETE FROM notifications WHERE user_id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            return ps.executeUpdate();
+        }
+    }
+
     private Notification map(ResultSet rs) throws SQLException {
         Notification n = new Notification();
         n.setId(rs.getInt("id"));

--- a/src/com/dao/OrderDAO.java
+++ b/src/com/dao/OrderDAO.java
@@ -114,6 +114,32 @@ public class OrderDAO {
         }
     }
 
+    /**
+     * Delete an order along with its items.
+     */
+    public int delete(int id) throws SQLException {
+        // Remove order items first to satisfy foreign key constraints
+        itemDAO.deleteByOrder(id);
+        String sql = "DELETE FROM orders WHERE id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            return ps.executeUpdate();
+        }
+    }
+
+    /**
+     * Delete all orders (and their items) for a specific user.
+     */
+    public int deleteByUser(int userId) throws SQLException {
+        List<Order> list = listByUser(userId);
+        int total = 0;
+        for (Order o : list) {
+            total += delete(o.getId());
+        }
+        return total;
+    }
+
     private Order map(ResultSet rs) throws SQLException {
         Order o = new Order();
         o.setId(rs.getInt("id"));

--- a/src/com/dao/OrderItemDAO.java
+++ b/src/com/dao/OrderItemDAO.java
@@ -38,6 +38,18 @@ public class OrderItemDAO {
         return list;
     }
 
+    /**
+     * Delete order items for a specific order.
+     */
+    public int deleteByOrder(int orderId) throws SQLException {
+        String sql = "DELETE FROM order_items WHERE order_id=?";
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, orderId);
+            return ps.executeUpdate();
+        }
+    }
+
     private OrderItem map(ResultSet rs) throws SQLException {
         OrderItem oi = new OrderItem();
         oi.setId(rs.getInt("id"));

--- a/web/admin/pages/user/delete_user.jsp
+++ b/web/admin/pages/user/delete_user.jsp
@@ -7,7 +7,7 @@
     response.setCharacterEncoding("UTF-8");
     
     String action = request.getParameter("action");
-    PrintWriter out = response.getWriter();
+    PrintWriter writer = response.getWriter();
     
     try {
         if ("single".equals(action)) {
@@ -18,12 +18,12 @@
                 boolean success = ServiceLayer.deleteUserById(userId);
                 
                 if (success) {
-                    out.print("{\"success\": true, \"message\": \"用户删除成功\"}");
+                    writer.print("{\"success\": true, \"message\": \"用户删除成功\"}");
                 } else {
-                    out.print("{\"success\": false, \"message\": \"用户删除失败\"}");
+                    writer.print("{\"success\": false, \"message\": \"用户删除失败\"}");
                 }
             } else {
-                out.print("{\"success\": false, \"message\": \"用户ID不能为空\"}");
+                writer.print("{\"success\": false, \"message\": \"用户ID不能为空\"}");
             }
         } else if ("batch".equals(action)) {
             // 批量删除
@@ -37,19 +37,22 @@
                 boolean success = ServiceLayer.batchDeleteUsers(userIds);
                 
                 if (success) {
-                    out.print("{\"success\": true, \"message\": \"批量删除成功，共删除 " + userIds.length + " 个用户\"}");
+                    writer.print("{\"success\": true, \"message\": \"批量删除成功，共删除 " + userIds.length + " 个用户\"}");
                 } else {
-                    out.print("{\"success\": false, \"message\": \"批量删除失败\"}");
+                    writer.print("{\"success\": false, \"message\": \"批量删除失败\"}");
                 }
             } else {
-                out.print("{\"success\": false, \"message\": \"请选择要删除的用户\"}");
+                writer.print("{\"success\": false, \"message\": \"请选择要删除的用户\"}");
             }
         } else {
-            out.print("{\"success\": false, \"message\": \"无效的操作类型\"}");
+            writer.print("{\"success\": false, \"message\": \"无效的操作类型\"}");
         }
     } catch (NumberFormatException e) {
-        out.print("{\"success\": false, \"message\": \"用户ID格式错误\"}");
+        writer.print("{\"success\": false, \"message\": \"用户ID格式错误\"}");
     } catch (Exception e) {
-        out.print("{\"success\": false, \"message\": \"删除操作失败: " + e.getMessage() + "\"}");
+        writer.print("{\"success\": false, \"message\": \"删除操作失败: " + e.getMessage() + "\"}");
+    } finally {
+        writer.flush();
+        writer.close();
     }
 %>

--- a/web/admin/pages/user/update_user.jsp
+++ b/web/admin/pages/user/update_user.jsp
@@ -13,7 +13,7 @@
     String email = request.getParameter("email");
     String phone = request.getParameter("phone");
 
-    PrintWriter out = response.getWriter();
+    PrintWriter writer = response.getWriter();
     try {
         if (userIdStr != null && !userIdStr.trim().isEmpty() && username != null && !username.trim().isEmpty()) {
             int userId = Integer.parseInt(userIdStr);
@@ -27,20 +27,20 @@
                 user.setPhone(phone);
                 boolean success = ServiceLayer.updateUser(user);
                 if (success) {
-                    out.print("{\"success\": true, \"message\": \"用户更新成功\"}");
+                    writer.print("{\"success\": true, \"message\": \"用户更新成功\"}");
                 } else {
-                    out.print("{\"success\": false, \"message\": \"用户更新失败\"}");
+                    writer.print("{\"success\": false, \"message\": \"用户更新失败\"}");
                 }
             } else {
-                out.print("{\"success\": false, \"message\": \"用户不存在\"}");
+                writer.print("{\"success\": false, \"message\": \"用户不存在\"}");
             }
         } else {
-            out.print("{\"success\": false, \"message\": \"参数不完整\"}");
+            writer.print("{\"success\": false, \"message\": \"参数不完整\"}");
         }
     } catch (Exception e) {
-        out.print("{\"success\": false, \"message\": \"更新用户时发生错误: " + e.getMessage() + "\"}");
+        writer.print("{\"success\": false, \"message\": \"更新用户时发生错误: " + e.getMessage() + "\"}");
     } finally {
-        out.flush();
-        out.close();
+        writer.flush();
+        writer.close();
     }
 %>


### PR DESCRIPTION
## Summary
- implement `deleteByUserId` helpers in DAO layer for addresses, carts, after-sales, notifications
- add order and order-item deletion utilities
- expose new model methods for cascading deletes
- update `ServiceLayer` to remove related data when deleting users and during batch delete
- fix user management JSP actions (rename `out` to `writer`)

## Testing
- `javac -d out -cp lib/mysql-connector-j-8.0.33.jar $(find src -name "*.java")`
- `java -cp lib/mysql-connector-j-8.0.33.jar:out test.AddressTest` *(fails: The url cannot be null)*

------
https://chatgpt.com/codex/tasks/task_e_68594a7f3530832fbf9b42b29d11de28