### PR TITLE
Fix admin access visibility on settings page

### DIFF
--- a/web/admin/checkAdmin.jsp
+++ b/web/admin/checkAdmin.jsp
@@ -1,0 +1,15 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="com.entity.User" %>
+<%
+    Object obj = session.getAttribute("user");
+    if (obj == null) {
+        response.sendRedirect(request.getContextPath() + "/login.jsp");
+        return;
+    }
+    User adminUser = (User) obj;
+    if (!adminUser.isAdmin()) {
+        response.sendRedirect(request.getContextPath() + "/index.jsp");
+        return;
+    }
+%>
+

--- a/web/admin/index.jsp
+++ b/web/admin/index.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ include file="checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/web/admin/pages/aftersales/index.jsp
+++ b/web/admin/pages/aftersales/index.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 获取搜索参数
     String searchUsername = request.getParameter("searchUsername");

--- a/web/admin/pages/notification/index.jsp
+++ b/web/admin/pages/notification/index.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 获取搜索参数
     String searchKeyword = request.getParameter("searchKeyword");

--- a/web/admin/pages/order/order-detail.jsp
+++ b/web/admin/pages/order/order-detail.jsp
@@ -7,6 +7,7 @@
 <%@ page import="com.entity.Product" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.text.SimpleDateFormat" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     String orderIdStr = request.getParameter("orderId");
     if (orderIdStr == null || orderIdStr.trim().isEmpty()) {

--- a/web/admin/pages/order/query.jsp
+++ b/web/admin/pages/order/query.jsp
@@ -7,6 +7,7 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 处理状态更新请求
     String action = request.getParameter("action");

--- a/web/admin/pages/product/index.jsp
+++ b/web/admin/pages/product/index.jsp
@@ -10,6 +10,7 @@
 <%@ page import="java.io.File" %>
 <%@ page import="java.io.IOException" %>
 <%@ page import="java.util.UUID" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 获取搜索参数
     String searchKeyword = request.getParameter("searchKeyword");

--- a/web/admin/pages/sn-binding/index.jsp
+++ b/web/admin/pages/sn-binding/index.jsp
@@ -5,6 +5,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.text.SimpleDateFormat" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 获取搜索参数
     String searchKeyword = request.getParameter("searchKeyword");

--- a/web/admin/pages/sn/index.jsp
+++ b/web/admin/pages/sn/index.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.entity.Product" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 获取搜索参数
     String searchKeyword = request.getParameter("searchKeyword");

--- a/web/admin/pages/user/address.jsp
+++ b/web/admin/pages/user/address.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.entity.Address" %>
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     // 处理各种操作
     String action = request.getParameter("action");

--- a/web/admin/pages/user/delete_user.jsp
+++ b/web/admin/pages/user/delete_user.jsp
@@ -2,6 +2,7 @@
 <%@ page import="com.ServiceLayer" %>
 <%@ page import="java.io.PrintWriter" %>
 <%@ page import="java.util.Arrays" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");

--- a/web/admin/pages/user/index.jsp
+++ b/web/admin/pages/user/index.jsp
@@ -2,6 +2,7 @@
 <%@ page import="com.ServiceLayer" %>
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.*" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     request.setCharacterEncoding("UTF-8");
     String action = request.getParameter("action");

--- a/web/admin/pages/user/update_user.jsp
+++ b/web/admin/pages/user/update_user.jsp
@@ -2,6 +2,7 @@
 <%@ page import="com.ServiceLayer" %>
 <%@ page import="com.entity.User" %>
 <%@ page import="java.io.PrintWriter" %>
+<%@ include file="../../checkAdmin.jsp" %>
 <%
     request.setCharacterEncoding("UTF-8");
     response.setContentType("application/json");

--- a/web/admin/test/binding-test.jsp
+++ b/web/admin/test/binding-test.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.entity.User" %>
 <%@ page import="com.entity.Binding" %>
 <%@ page import="java.util.List" %>
+<%@ include file="../checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>

--- a/web/admin/test/test-address.jsp
+++ b/web/admin/test/test-address.jsp
@@ -3,6 +3,7 @@
 <%@ page import="com.entity.Address" %>
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
+<%@ include file="../checkAdmin.jsp" %>
 
 <%
     // 获取所有用户用于测试

--- a/web/admin/test/test-aftersale.jsp
+++ b/web/admin/test/test-aftersale.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Date" %>
+<%@ include file="../checkAdmin.jsp" %>
 
 <%
     // 获取所有用户和售后工单用于测试

--- a/web/admin/test/test-notification.jsp
+++ b/web/admin/test/test-notification.jsp
@@ -4,6 +4,7 @@
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Date" %>
+<%@ include file="../checkAdmin.jsp" %>
 
 <%
     // 获取所有用户用于测试

--- a/web/admin/test/test-order.jsp
+++ b/web/admin/test/test-order.jsp
@@ -5,6 +5,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.math.BigDecimal" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ include file="../checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/admin/test/test-product-image.jsp
+++ b/web/admin/test/test-product-image.jsp
@@ -7,6 +7,7 @@
 <%@ page import="java.io.IOException" %>
 <%@ page import="java.util.UUID" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ include file="../checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/admin/test/test-product.jsp
+++ b/web/admin/test/test-product.jsp
@@ -4,6 +4,7 @@
 <%@ page import="java.util.List" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page import="java.math.BigDecimal" %>
+<%@ include file="../checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/admin/test/test-sncode.jsp
+++ b/web/admin/test/test-sncode.jsp
@@ -5,6 +5,7 @@
 <%@ page import="com.entity.Order" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Date" %>
+<%@ include file="../checkAdmin.jsp" %>
 
 <%
     // 获取所有商品和订单用于测试

--- a/web/admin/test/test-user-delete.jsp
+++ b/web/admin/test/test-user-delete.jsp
@@ -2,6 +2,7 @@
 <%@ page import="com.ServiceLayer" %>
 <%@ page import="com.entity.User" %>
 <%@ page import="java.util.List" %>
+<%@ include file="../checkAdmin.jsp" %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/web/settings.jsp
+++ b/web/settings.jsp
@@ -22,6 +22,7 @@
     <div class="settings-section">
         <div class="section-title">管理功能</div>
         <div class="settings-list">
+            <% if (u.isAdmin()) { %>
             <a href="/admin/index.jsp" class="settings-item admin-item">
                 <div class="settings-item-content">
                     <div class="settings-icon">⚙️</div>
@@ -29,6 +30,7 @@
                 </div>
                 <span class="arrow">></span>
             </a>
+            <% } %>
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- add `checkAdmin.jsp` to verify session user and redirect if not admin
- include new check on all admin-related JSP pages
- show admin login link on settings page only to admins

## Testing
- `javac -d out -cp lib/mysql-connector-j-8.0.33.jar $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_685968bdbd14832f9b1dbbd954576882